### PR TITLE
Fixed login / logout sheets & added signup functionality

### DIFF
--- a/TheKnow.xcodeproj/project.pbxproj
+++ b/TheKnow.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		291FDECC2635C94F00181FE8 /* YelpAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 291FDECB2635C94F00181FE8 /* YelpAPI.swift */; };
 		A207D72C263F3D41006BAEC8 /* CollectionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A207D72B263F3D41006BAEC8 /* CollectionViewModel.swift */; };
+		A207D72E26405584006BAEC8 /* AccountViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A207D72D26405584006BAEC8 /* AccountViewModel.swift */; };
 		A22ACC7326371C9500C04639 /* CollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A22ACC7226371C9500C04639 /* CollectionView.swift */; };
 		A22ACC7626371CA200C04639 /* PlaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A22ACC7526371CA200C04639 /* PlaceView.swift */; };
 		A22ACC7926371CD000C04639 /* AddCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A22ACC7826371CD000C04639 /* AddCollectionView.swift */; };
@@ -45,6 +46,7 @@
 /* Begin PBXFileReference section */
 		291FDECB2635C94F00181FE8 /* YelpAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YelpAPI.swift; sourceTree = "<group>"; };
 		A207D72B263F3D41006BAEC8 /* CollectionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionViewModel.swift; sourceTree = "<group>"; };
+		A207D72D26405584006BAEC8 /* AccountViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountViewModel.swift; sourceTree = "<group>"; };
 		A22ACC7226371C9500C04639 /* CollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionView.swift; sourceTree = "<group>"; };
 		A22ACC7526371CA200C04639 /* PlaceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceView.swift; sourceTree = "<group>"; };
 		A22ACC7826371CD000C04639 /* AddCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddCollectionView.swift; sourceTree = "<group>"; };
@@ -157,6 +159,7 @@
 				A27DD5CE2635F33400A083CF /* SignupViewModel.swift */,
 				A27DD5D12635F69B00A083CF /* CollectionsViewModel.swift */,
 				A207D72B263F3D41006BAEC8 /* CollectionViewModel.swift */,
+				A207D72D26405584006BAEC8 /* AccountViewModel.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -326,6 +329,7 @@
 				A27DD5D52635F95B00A083CF /* AccountView.swift in Sources */,
 				A2641F6E26017CE100A0F427 /* Strings.swift in Sources */,
 				A27DD5C22635DCC400A083CF /* LoggedOutView.swift in Sources */,
+				A207D72E26405584006BAEC8 /* AccountViewModel.swift in Sources */,
 				A27EDE2126362A8E0081104D /* MapView.swift in Sources */,
 				A2FF88482601668C00D16EBC /* TheKnowApp.swift in Sources */,
 				A27DD5C72635E04400A083CF /* SignupView.swift in Sources */,

--- a/TheKnow/Models/API.swift
+++ b/TheKnow/Models/API.swift
@@ -23,6 +23,11 @@ struct Headers {
 struct BodyParams {
     static let USER = "user"
     static let COLLECTION = "collection"
+    static let EMAIL = "email"
+    static let FIRSTNAME = "firstname"
+    static let LASTNAME = "lastname"
+    static let PASSWORD = "pass"
+    static let PASSWORD_CONFIRM = "pass2"
 }
 
 class API {

--- a/TheKnow/Strings.swift
+++ b/TheKnow/Strings.swift
@@ -16,7 +16,7 @@ struct Strings {
     static let LOG_IN = "Log In"
     static let LOG_OUT = "Log Out"
     static let SIGN_UP = "Sign Up"
-    static let USERNAME = "Username"
+    static let EMAIL = "Email"
     static let PASSWORD = "Password"
     static let ENTER_PASSWORD = "Enter password"
     static let VERIFY_PASSWORD = "Confirm password"

--- a/TheKnow/ViewModels/AccountViewModel.swift
+++ b/TheKnow/ViewModels/AccountViewModel.swift
@@ -1,0 +1,13 @@
+//
+//  AccountViewModel.swift
+//  TheKnow
+//
+//  Created by Tom Margosian on 5/3/21.
+//
+
+import Foundation
+import SwiftUI
+
+class AccountViewModel: ObservableObject {
+    
+}

--- a/TheKnow/ViewModels/LoginViewModel.swift
+++ b/TheKnow/ViewModels/LoginViewModel.swift
@@ -9,7 +9,7 @@ import Foundation
 import Combine
 
 class LoginViewModel: ObservableObject {
-    @Published var username: String = ""
+    @Published var email: String = ""
     @Published var password: String = ""
     
     @Published var isValid: Bool = false
@@ -17,7 +17,7 @@ class LoginViewModel: ObservableObject {
     var cancellableSet: Set<AnyCancellable> = []
     
     var isUsernameValidPublisher: AnyPublisher<Bool,Never> {
-        $username
+        $email
             .debounce(for: 0.8, scheduler: RunLoop.main)
             .removeDuplicates()
             .map {input in

--- a/TheKnow/ViewModels/UserViewModel.swift
+++ b/TheKnow/ViewModels/UserViewModel.swift
@@ -13,16 +13,16 @@ class UserViewModel: ObservableObject {
     let defaults = UserDefaults.standard
 
     @Published var loggedIn: Bool = false
-//    @Published var loginSucess: Bool = false
-//    @Published var logoutSuccess: Bool = false
     
-    @Published var username: String? = ""
+    @Published var showAccountSheet: Bool = false
+    
+    @Published var email: String? = ""
     @Published var id: String? = ""
     @Published var token: String? = ""
     
-    func login(_username: String, password: String, completion: @escaping (Bool) -> Void) {
+    func login(_email: String, password: String, completion: @escaping (Bool) -> Void) {
         let parameters = [
-            "username": _username,
+            "email": _email,
             "password": password
         ]
         AF.request(Routes.LOGIN,
@@ -39,38 +39,43 @@ class UserViewModel: ObservableObject {
             /// Add userData to object
             self.token = response.contents.user?.token
             self.id = response.contents.user?.id
-            self.username = _username
+            self.email = _email
             
             /// Add userData to UserDefaults
             self.defaults.set(self.token, forKey: "token")
             self.defaults.set(self.loggedIn, forKey: "loggedIn")
-            self.defaults.set(self.username, forKey: "username")
+            self.defaults.set(self.email, forKey: "email")
             self.defaults.set(self.id, forKey: "id")
             
             completion(true)
         }
     }
     
-    func signup(_username: String, password: String, password2: String) {
-        print("Username: \(_username), Password: \(password)")
+    func signup(_email: String, firstname: String, lastname: String, password: String, password2: String, completion: @escaping (Bool) -> Void) {
+        print("Email: \(_email), Password: \(password)")
         let parameters = [
-            "username": _username,
-            "pass": password,
-            "pass2": password2,
+            BodyParams.EMAIL: _email,
+            BodyParams.FIRSTNAME: firstname,
+            BodyParams.LASTNAME: lastname,
+            BodyParams.PASSWORD: password,
+            BodyParams.PASSWORD_CONFIRM: password2,
         ]
-
         AF.request(Routes.SIGNUP,
                    method: .post,
                    parameters: parameters
         )
         .validate()
         .responseDecodable(of: APIResponse.self) { (response) in
-            guard let response = response.value else { return }
+            guard let response = response.value else {
+                completion(false)
+                return
+            }
             print(response)
             self.token = response.contents.user?.token
             self.id = response.contents.user?.id
-            self.username = _username
-//            self.loginSucess = true
+            self.email = _email
+            completion(true)
+            
         }
     }
     
@@ -85,14 +90,14 @@ class UserViewModel: ObservableObject {
                 }
                 
                 /// Remove user details
-                self.username = ""
+                self.email = ""
                 self.id = ""
                 self.token = ""
                 
                 /// Remove from UserDefaults
                 self.defaults.set(self.token, forKey: "token")
 //                self.defaults.set(self.loggedIn, forKey: "loggedIn")
-                self.defaults.set(self.username, forKey: "username")
+                self.defaults.set(self.email, forKey: "email")
                 self.defaults.set(self.id, forKey: "id")
                 
                 completion(true)

--- a/TheKnow/Views/ContentView.swift
+++ b/TheKnow/Views/ContentView.swift
@@ -13,7 +13,7 @@ struct ContentView: View {
     
     @AppStorage("token") var UserDefaultsToken = ""
     @AppStorage("loggedIn") var UserDefaultsLoggedIn = false
-    @AppStorage("username") var UserDefaultsUsername = ""
+    @AppStorage("email") var UserDefaultsEmail = ""
     @AppStorage("id") var UserDefaultsId = ""
     
 //    init() {
@@ -23,16 +23,16 @@ struct ContentView: View {
         ZStack {
             if (user.loggedIn) {
                 LoggedInView()
-                    .transition(.opacity)
+                    .transition(.move(edge: .trailing))
             } else {
                 LoggedOutView()
-                    .transition(.opacity)
+                    .transition(.move(edge: .leading))
             }
         }.onAppear {
             user.loggedIn = UserDefaultsLoggedIn
             user.token = UserDefaultsToken
             user.id = UserDefaultsId
-            user.username = UserDefaultsUsername
+            user.email = UserDefaultsEmail
         }
     }
     

--- a/TheKnow/Views/DetailViews/AccountView.swift
+++ b/TheKnow/Views/DetailViews/AccountView.swift
@@ -10,52 +10,62 @@ import SwiftUI
 struct AccountView: View {
     
     @EnvironmentObject var user: UserViewModel
+    @ObservedObject var accountViewModel = AccountViewModel()
     
     @Binding var showing: Bool
     
     var body: some View {
         ZStack (alignment: .top) {
-            Form {
-                Section (header: Text(Strings.ACCOUNT_NAME)) {
-                    Text("\(user.username ?? Strings.USERNAME_NOT_FOUND)")
-                }
-                Section (header: Text("User ID (DEV)")) {
-                    Text("\(user.id ?? Strings.USERNAME_NOT_FOUND)")
-                }
-                Section (header: Text("Current Token (DEV)")) {
-                    Text("\(user.token ?? Strings.USERNAME_NOT_FOUND)")
-                }
+            NavigationView {
+                Form {
+                    Section (header: Text(Strings.ACCOUNT_NAME)) {
+                        Text("\(user.email ?? Strings.USERNAME_NOT_FOUND)")
+                    }
+                    Section (header: Text("User ID (DEV)")) {
+                        Text("\(user.id ?? Strings.USERNAME_NOT_FOUND)")
+                    }
+                    Section (header: Text("Current Token (DEV)")) {
+                        Text("\(user.token ?? Strings.USERNAME_NOT_FOUND)")
+                    }
 
-                Section (header: Text(Strings.ACCOUNT_ACTIONS)) {
-                    Button(action: {
-                    }, label: {
-                        Text(Strings.CHANGE_PASSWORD)
-                    })
-                    .disabled(true)
+                    Section (header: Text(Strings.ACCOUNT_ACTIONS)) {
+                        Button(action: {
+                            
+                        }, label: {
+                            Text(Strings.CHANGE_PASSWORD)
+                        })
+                        .disabled(true)
 
-                    Button(action: {
-                        withAnimation {
-                            user.logout() { (success) in
-                                if (success) {
-                                    DispatchQueue.main.async {
-                                        showing = false
-                                    }
-                                    withAnimation {
-                                        user.loggedIn = false
-                                    }
-                                    
-                                }
-                            }
-                                
-                            }
+                        Button(action: {
+                            performLogout()
+                        }, label: {
+                            Text(Strings.LOG_OUT)
+                        })
+                    }
+                }
+                .navigationTitle(Strings.ACCOUNT)
+
+            }
+            Image(systemName: "chevron.compact.down")
+                .foregroundColor(Color(.systemGray3))
+                .font(.system(.largeTitle))
+                .padding(.top, 15)
+
+        } // ZStack
+    }
     
-                    }, label: {
-                        Text(Strings.LOG_OUT)
-                    })
+    func performLogout() {
+        user.logout() { (success) in
+            if (success) {
+                showing = false
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+                    withAnimation {
+                        user.loggedIn = false
+                    }
                 }
             }
-            .navigationTitle(Strings.ACCOUNT)
-        } // ZStack
+        }
+
     }
 }
 

--- a/TheKnow/Views/DetailViews/CollectionsView.swift
+++ b/TheKnow/Views/DetailViews/CollectionsView.swift
@@ -60,7 +60,7 @@ struct CollectionsView: View {
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
                     Button(action: {
-                        showAccountSheet = true
+                        self.showAccountSheet = true
                     }, label: {
                         Image(systemName: "person.circle")
                             .font(.largeTitle)

--- a/TheKnow/Views/LoggedOut/LoggedOutView.swift
+++ b/TheKnow/Views/LoggedOut/LoggedOutView.swift
@@ -12,7 +12,6 @@ struct LoggedOutView: View {
     @EnvironmentObject var user: UserViewModel
         
     var body: some View {
-//        NavigationView {
             VStack {
                 Text(Strings.LOGGED_OUT_WELCOME)
                     .font(.system(.largeTitle, design: .rounded))
@@ -21,8 +20,6 @@ struct LoggedOutView: View {
                 Spacer()
                 LoggedOutViewButtons()
             }
-//        }
-//        .navigationViewStyle(StackNavigationViewStyle())
 
         
     }

--- a/TheKnow/Views/LoggedOut/LoginView.swift
+++ b/TheKnow/Views/LoggedOut/LoginView.swift
@@ -14,46 +14,54 @@ struct LoginView: View {
 
     var body: some View {
         ZStack (alignment: .top) {
-            Form {
-                Section {
-                    TextField(Strings.USERNAME, text: $loginViewModel.username)
+            NavigationView {
+                Form {
+                    Section {
+                        TextField(Strings.EMAIL, text: $loginViewModel.email)
+                            .autocapitalization(.none)
+                            .disableAutocorrection(true)
+                            .keyboardType(.emailAddress)
+                        SecureField(Strings.PASSWORD, text: $loginViewModel.password) {
+                            performLogin()
+                        }
                         .autocapitalization(.none)
-                    SecureField(Strings.PASSWORD, text: $loginViewModel.password) {
-                        user.login(_username: loginViewModel.username, password: loginViewModel.password) { (success) in
-                            if (success) {
-                                withAnimation {
-                                    user.loggedIn = true
-                                }
-                                DispatchQueue.main.async {
-                                    showing = false
-                                }
-                                
-                            }
+                        .keyboardType(.default)
+                            
+
+                    }
+                    Section {
+                        Button(action: {
+                            performLogin()
+                        }, label: {
+                            Text(Strings.LOG_IN)
+                                .frame(maxWidth: .infinity, alignment: .center)
+                        })
+                        .disabled(!loginViewModel.isValid)
+                    } // Section
+                } // Form
+                .navigationTitle(Text(Strings.LOG_IN))
+            }
+            Image(systemName: "chevron.compact.down")
+                .foregroundColor(Color(.systemGray3))
+                .font(.system(.largeTitle))
+                .padding(.top, 15)
+
+        } // ZStack
+    } // Body
+    
+    func performLogin() {
+//        if(loginViewModel.isValid) {
+            user.login(_email: loginViewModel.email, password: loginViewModel.password) { (success) in
+                if (success) {
+                    showing = false
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+                        withAnimation {
+                            user.loggedIn = true
                         }
                     }
-                    .autocapitalization(.none)
-                        
-
                 }
-                Section {
-                    Button(action: {
-                        user.login(_username: loginViewModel.username, password: loginViewModel.password) { (success) in
-                            if (success) {
-                                withAnimation {
-                                    user.loggedIn = true
-                                }
-                                showing = false
-                            }
-                        }
-                    }, label: {
-                        Text(Strings.LOG_IN)
-                            .frame(maxWidth: .infinity, alignment: .center)
-                    })
-                    .disabled(!loginViewModel.isValid)
-                } // Section
-            } // Form
-            .navigationTitle(Text(Strings.LOG_IN))
-        } // ZStack
+            }
+//        }
     }
 }
 

--- a/TheKnow/Views/LoggedOut/SignupView.swift
+++ b/TheKnow/Views/LoggedOut/SignupView.swift
@@ -14,60 +14,114 @@ struct SignupView: View {
 
     var body: some View {
         ZStack (alignment: .top){
-            Form {
-                Section (header:
-                            Text(Strings.USERNAME)
-                         , footer:
-                            Text(signupViewModel.usernameMessage)
-                                .foregroundColor(.red)
-                ) {
-                    TextField(
-                        Strings.USERNAME,
-                        text: $signupViewModel.username
-                    )
-                        .autocapitalization(.none)
-                } // Section
-                
-                Section (header:
-                            Text(Strings.PASSWORD)
-                         , footer:
-                            Text(signupViewModel.passwordMessage)
-                                .foregroundColor(.red)
+            NavigationView {
+                Form {
+                    Section (header:
+                                Text(Strings.EMAIL)
+                             , footer:
+                                Text(signupViewModel.emailMessage)
+                                    .foregroundColor(.red)
                     ) {
-                    SecureField(
-                        Strings.ENTER_PASSWORD,
-                        text: $signupViewModel.password
-                    )
+                        TextField(
+                            Strings.EMAIL,
+                            text: $signupViewModel.email,
+                            onEditingChanged: { _ in
+                                signupViewModel.validateEmail()
+                            }
+                        )
                         .autocapitalization(.none)
-                    SecureField(
-                        Strings.VERIFY_PASSWORD,
-                        text: $signupViewModel.passwordConfirm
-                    )
+                        .keyboardType(.emailAddress)
+                    } // Section
+                    
+                    Section (header:
+                                Text("Name")
+                             , footer:
+                                Text(signupViewModel.nameMessage)
+                                    .foregroundColor(.red)
+                        ) {
+                        TextField(
+                            "First Name",
+                            text: $signupViewModel.firstname,
+                            onEditingChanged: { _ in
+                                signupViewModel.validateName()
+                            }
+                        )
+                        .disableAutocorrection(true)
+                        TextField(
+                            "Last Name",
+                            text: $signupViewModel.lastname,
+                            onEditingChanged: { _ in
+                                signupViewModel.validateSignup()
+                            }
+                        )
+                        
+                        .disableAutocorrection(true)
+                    } // Section
+
+                    
+                    Section (header:
+                                Text(Strings.PASSWORD)
+                             , footer:
+                                Text(signupViewModel.passwordMessage)
+                                    .foregroundColor(.red)
+                        ) {
+                        SecureField(
+                            Strings.ENTER_PASSWORD,
+                            text: $signupViewModel.password
+                        )
                         .autocapitalization(.none)
-                } // Section
-                
-                Section {
-                    Button(action: {
-                        withAnimation {
-                            user.signup(
-                                _username: signupViewModel.username,
-                                password: signupViewModel.password,
-                                password2: signupViewModel.passwordConfirm
-                            )
+                        .onTapGesture {
+                            signupViewModel.validatePassword()
                         }
-                    }, label: {
-                        Text(Strings.SIGN_UP)
-                            .frame(maxWidth: .infinity, alignment: .center)
-                    })
-                    .disabled(!signupViewModel.isValid)
-                } // Section
-                
-            } // Form
-            .navigationTitle(Text(Strings.SIGN_UP))            
+                        SecureField(
+                            Strings.VERIFY_PASSWORD,
+                            text: $signupViewModel.passwordConfirm
+                        )
+                        .autocapitalization(.none)
+                        .onTapGesture {
+                            signupViewModel.validatePassword()
+                        }
+                    } // Section
+                    
+                    Section {
+                        Button(action: {
+                            performSignup()
+                        }, label: {
+                            Text(Strings.SIGN_UP)
+                                .frame(maxWidth: .infinity, alignment: .center)
+                        })
+                        .disabled(!signupViewModel.isValid)
+                    } // Section
+                    
+                } // Form
+                .navigationTitle(Text(Strings.SIGN_UP))
+                Image(systemName: "chevron.compact.down")
+                    .foregroundColor(Color(.systemGray3))
+                    .font(.system(.largeTitle))
+                    .padding(.top, 15)
+
+            }
         } // ZStack
+    } // Body
+    
+    func performSignup() {
         
-        
-        
+        user.signup(
+            _email: signupViewModel.email,
+            firstname: signupViewModel.firstname,
+            lastname: signupViewModel.lastname,
+            password: signupViewModel.password,
+            password2: signupViewModel.passwordConfirm
+        ) { (success) in
+            if (success) {
+                showing = false
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+                    withAnimation {
+                        user.loggedIn = true
+                    }
+                }
+            }
+        } // user.signup
     }
 }
 


### PR DESCRIPTION
Since the AccountView is on a sheet which is presented from the CollectionView, a race condition had presented itself. When the Logout function was called from the AccountView, sometimes the view hierarchy would change before the collectionsView had the ability to update it's state variable and dismiss the accountSheet.  In this case, the AccountView sheet would remain presented, but with no data in any of the fields. This was solved by adding an AsyncAfter call to update the loggedIn state after a short delay, to allow for the sheet to properly dismiss.  This functionality has been added to the AccountView sheet in the LoggedIn state, and the LoginView and SignupView sheets in the LoggedOut state.

Also implemented Sign up functionality with the API, and modified publishers in SignupViewModel to be more descriptive.